### PR TITLE
Fix nowrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@
 - Under index.php you can change bot username, bot icon and add token channels
 - Create outgoing webhook for each channel like this params :
      ![alt picture](https://i.gyazo.com/88f2a3f5fba86c6e030ca2a5d3c090af.png)
+- After creating the webhook, copy the generated token, and add it to the `$config` array, to the `token` key, in `index.php`. E.g.:
+
+```
+$config = [
+    'username' => 'B4o4T', // username display on chat
+    'icon_url' => 'https://les-404.xyz/img/B4o4T.png', // icon display on chat
+    'token' => [
+        'wx58em1ss3ya8gatdzddem9ada'
+    ] // Channels token
+```
 
 ### Add and edit messages/responses
 - Access on the index.php like : https://your-domain.com/mattermods/mbot

--- a/index.php
+++ b/index.php
@@ -269,7 +269,6 @@ if ($_POST && array_key_exists('responses', $_POST)) {
             border-radius: 0px;
             resize: none;
             min-height: 95px;
-            white-space: nowrap;
         }
 
         .remove {
@@ -336,10 +335,17 @@ if ($_POST && array_key_exists('responses', $_POST)) {
         $('#add-row').on('click', function () {
             $('tbody').append(
                 '<tr>' +
-                '<td><textarea class="form-control" placeholder="One per line"></textarea></td>' +
-                '<td><textarea class="form-control" placeholder="One per line (random choice)"></textarea>' +
+                '<td><textarea class="form-control" placeholder="One per line" wrap="off"></textarea></td>' +
+                '<td><textarea class="form-control" placeholder="One per line (random choice)" wrap="off"></textarea>' +
                 '<button class="remove"><i class="fa fa-trash" aria-hidden="true"></i></button></td>' +
                 '</tr>');
+        });
+
+        $(document).ready(function() {
+            $('textarea').each(function(){
+                $(this).attr('wrap', 'off');
+
+            });
         });
 
         // remove the selected row


### PR DESCRIPTION
Hello again,

I copy and paste the commit message, where I've made the required explanations:

> "no-wrap" as textarea attribute instead of CSS (problems with Firefox)
>
> The 'white-space: nowrap' CSS rule behaves weirdly with Firefox (cannot
> make line breaks; tested with 50.0), but setting is as an attribute of
> the textarea works fine (tested with Firefox & Chrome).

Cheers,
Julen